### PR TITLE
cli: robium-ai app command group (reference-apps spec v1)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,8 @@ npx robium-ai app describe indoor-navigation  # one app's metadata (JSON)
 npx robium-ai app check indoor-navigation     # preflight: doctor facts + make check
 npx robium-ai app run indoor-navigation       # the default demo
 npx robium-ai app run indoor-navigation --scenario slam
+npx robium-ai app validate --json               # schema-check every app (CI)
+npx robium-ai app new my-app --from indoor-navigation   # scaffold by copy
 ```
 
 `app` commands find the apps repo via `--dir <path>`, else `$ROBIUM_APPS_DIR`,

--- a/cli/README.md
+++ b/cli/README.md
@@ -26,7 +26,20 @@ npx robium-ai doctor --json   # machine-readable (for agents/scripts)
 # Browse the skill catalog
 npx robium-ai skills          # all skills
 npx robium-ai skills nav      # filter
+
+# Work with reference applications (robium-app.yaml contract)
+npx robium-ai app list                        # catalog of apps in the apps repo
+npx robium-ai app describe indoor-navigation  # one app's metadata (JSON)
+npx robium-ai app check indoor-navigation     # preflight: doctor facts + make check
+npx robium-ai app run indoor-navigation       # the default demo
+npx robium-ai app run indoor-navigation --scenario slam
 ```
+
+`app` commands find the apps repo via `--dir <path>`, else `$ROBIUM_APPS_DIR`,
+else by walking up from the current directory to the first repo containing
+`REGISTRY.md` plus `robium-app.yaml` files. They exec each app's declared
+commands (Make verbs); nothing is reimplemented in the CLI. See the
+reference-apps spec: `docs/superpowers/specs/2026-08-05-reference-applications-design.md`.
 
 ## How setup works
 

--- a/cli/bin/robium.js
+++ b/cli/bin/robium.js
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { setup } from '../src/setup.js';
 import { doctor } from '../src/doctor.js';
 import { skills } from '../src/skills.js';
+import { appCmd } from '../src/apps.js';
 
 const USAGE = `robium: robotics skill pack for coding agents (https://robium.ai)
 
@@ -13,6 +14,8 @@ Usage:
   npx robium-ai install                  Alias for setup
   npx robium-ai doctor [--json]          Check your environment
   npx robium-ai skills [query]           Browse the skill catalog
+  npx robium-ai app <subcommand>         Work with reference applications
+                                         (list | describe | check | run)
 
 Setup options:
   --agent <name>   Target one agent instead of auto-detecting
@@ -37,6 +40,8 @@ export function parseArgs(argv) {
     else if (a === '--agent') args.flags.agent = argv[++i];
     else if (a.startsWith('--dir=')) args.flags.dir = a.slice('--dir='.length);
     else if (a === '--dir') args.flags.dir = argv[++i];
+    else if (a.startsWith('--scenario=')) args.flags.scenario = a.slice('--scenario='.length);
+    else if (a === '--scenario') args.flags.scenario = argv[++i];
     else if (a.startsWith('-')) args.flags.unknown = a;
     else args._.push(a);
   }
@@ -69,6 +74,8 @@ export async function main(argv) {
       return doctor({ json: flags.json });
     case 'skills':
       return skills({ query: pos[1] });
+    case 'app':
+      return appCmd({ args: pos.slice(1), flags });
     default:
       console.error(`Unknown command: ${cmd}\n\n${USAGE}`);
       return 1;

--- a/cli/bin/robium.js
+++ b/cli/bin/robium.js
@@ -15,7 +15,8 @@ Usage:
   npx robium-ai doctor [--json]          Check your environment
   npx robium-ai skills [query]           Browse the skill catalog
   npx robium-ai app <subcommand>         Work with reference applications
-                                         (list | describe | check | run)
+                                         (list | describe | check | run |
+                                          validate | new)
 
 Setup options:
   --agent <name>   Target one agent instead of auto-detecting
@@ -42,6 +43,8 @@ export function parseArgs(argv) {
     else if (a === '--dir') args.flags.dir = argv[++i];
     else if (a.startsWith('--scenario=')) args.flags.scenario = a.slice('--scenario='.length);
     else if (a === '--scenario') args.flags.scenario = argv[++i];
+    else if (a.startsWith('--from=')) args.flags.from = a.slice('--from='.length);
+    else if (a === '--from') args.flags.from = argv[++i];
     else if (a.startsWith('-')) args.flags.unknown = a;
     else args._.push(a);
   }

--- a/cli/src/appNew.js
+++ b/cli/src/appNew.js
@@ -1,0 +1,58 @@
+import { cpSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+// Scaffold by copying the closest shipped app (the REGISTRY.md "Bootstrap
+// for" rule), never from abstract templates. Build/state artifacts are
+// excluded; everything else comes across verbatim for the new app to diverge.
+
+const EXCLUDE = new Set([
+  '.venv', 'outputs', 'node_modules', '__pycache__', '.pytest_cache',
+  'build', 'install', 'log', 'bags', '.DS_Store',
+]);
+
+export function scaffoldApp({ appsDir, id, from, log = console.log }) {
+  if (!id || !/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+    log(`Invalid app id "${id ?? ''}": use lowercase letters, digits, and dashes.`);
+    return 1;
+  }
+  if (!from) {
+    log('Missing --from <existing-app-id>: scaffolding copies the closest shipped app (see REGISTRY.md "Bootstrap for").');
+    return 1;
+  }
+  const src = path.join(appsDir, from);
+  const dst = path.join(appsDir, id);
+  if (!existsSync(path.join(src, 'robium-app.yaml'))) {
+    log(`Source app "${from}" not found (no ${from}/robium-app.yaml in ${appsDir}).`);
+    return 1;
+  }
+  if (existsSync(dst)) {
+    log(`Target "${id}" already exists at ${dst}.`);
+    return 1;
+  }
+
+  cpSync(src, dst, {
+    recursive: true,
+    filter: (p) => !EXCLUDE.has(path.basename(p)),
+  });
+
+  // Reset the metadata contract for the new app; everything else is the
+  // author's to rewrite as the app diverges.
+  const yamlPath = path.join(dst, 'robium-app.yaml');
+  let yaml = readFileSync(yamlPath, 'utf8');
+  yaml = yaml
+    .replace(/^id: .*$/m, `id: ${id}`)
+    .replace(/^name: .*$/m, `name: ${id} (bootstrapped from ${from})`)
+    .replace(/^summary: .*$/m, `summary: TODO - one-sentence outcome (bootstrapped from ${from}, rewrite me)`)
+    .replace(/^version: .*$/m, 'version: 0.1.0')
+    .replace(/^status: .*$/m, 'status: experimental');
+  writeFileSync(yamlPath, yaml);
+
+  log(`Scaffolded ${id} from ${from} at ${dst}\n`);
+  log('Next steps (an app is not done until these are done):');
+  log('  1. Run the robium-architect agent to write docs/architecture-brief.md for the NEW problem');
+  log('  2. Rewrite robium-app.yaml summary/tags/scenarios as the app diverges');
+  log(`  3. Rename source packages/modules copied from ${from}`);
+  log('  4. Make `make smoke` mean something for this app, then keep it green');
+  log('  5. Add the REGISTRY.md quick-index row + card IN THE SAME COMMIT as the app');
+  return 0;
+}

--- a/cli/src/appValidate.js
+++ b/cli/src/appValidate.js
@@ -1,0 +1,102 @@
+import path from 'node:path';
+import { loadApps } from './apps.js';
+
+// robium-app.yaml schema "1" validation (reference-apps spec section 5).
+// Precise, per-field errors; JSON output for CI.
+
+const STATUS = ['experimental', 'stable', 'archived'];
+const KIND = ['docker', 'uv', 'remote-gpu', 'hardware'];
+const GPU = ['none', 'optional', 'required', 'remote'];
+
+export function validateApp(app) {
+  const errors = [];
+  const warn = [];
+  const need = (cond, msg) => { if (!cond) errors.push(msg); };
+
+  need(app.schema_version === '1', `schema_version must be "1" (got ${JSON.stringify(app.schema_version)})`);
+  need(typeof app.id === 'string' && app.id.length > 0, 'id is required');
+  if (app.id && app.dir) {
+    need(path.basename(app.dir) === app.id, `id "${app.id}" must equal the directory name "${path.basename(app.dir)}"`);
+  }
+  need(typeof app.name === 'string' && app.name.length > 0, 'name is required');
+  need(typeof app.summary === 'string' && app.summary.length > 0, 'summary is required');
+  need(typeof app.version === 'string' && /^\d+\.\d+\.\d+$/.test(app.version ?? ''), `version must be MAJOR.MINOR.PATCH (got ${JSON.stringify(app.version)})`);
+  need(STATUS.includes(app.status), `status must be one of ${STATUS.join(' | ')} (got ${JSON.stringify(app.status)})`);
+  need(typeof app.license === 'string' && app.license.length > 0, 'license is required');
+
+  need(app.runtime && typeof app.runtime === 'object', 'runtime section is required');
+  if (app.runtime) {
+    need(KIND.includes(app.runtime.kind), `runtime.kind must be one of ${KIND.join(' | ')} (got ${JSON.stringify(app.runtime.kind)})`);
+    need(typeof app.runtime.entrypoint === 'string' && app.runtime.entrypoint.length > 0, 'runtime.entrypoint is required');
+  }
+
+  need(app.verbs && typeof app.verbs === 'object', 'verbs section is required');
+  if (app.verbs) {
+    need(typeof app.verbs.smoke === 'string', 'verbs.smoke is required (the pass bar)');
+    for (const [k, v] of Object.entries(app.verbs)) {
+      need(typeof v === 'string' && v.length > 0, `verbs.${k} must be a command string`);
+    }
+    if (app.status !== 'archived' && !app.verbs.check) warn.push('no verbs.check: preflight is doctor-facts only');
+  }
+
+  const scenarioNames = Object.keys(app.scenarios ?? {});
+  for (const [nameKey, s] of Object.entries(app.scenarios ?? {})) {
+    need(s && typeof s === 'object' && typeof s.command === 'string', `scenarios.${nameKey}.command is required`);
+    if (s && typeof s === 'object' && !s.summary) warn.push(`scenarios.${nameKey} has no summary`);
+  }
+
+  need(app.requirements && typeof app.requirements === 'object', 'requirements section is required');
+  if (app.requirements) {
+    need(Array.isArray(app.requirements.hardware), 'requirements.hardware must be an array');
+    need(GPU.includes(app.requirements.gpu), `requirements.gpu must be one of ${GPU.join(' | ')} (got ${JSON.stringify(app.requirements.gpu)})`);
+  }
+
+  need(app.demo && typeof app.demo === 'object', 'demo section is required');
+  if (app.demo) {
+    need(typeof app.demo.hosted === 'boolean', 'demo.hosted must be true or false');
+    const ds = app.demo.default_scenario;
+    need(typeof ds === 'string', 'demo.default_scenario is required');
+    if (typeof ds === 'string') {
+      const known = ds === 'demo' || scenarioNames.includes(ds) || typeof app.verbs?.[ds] === 'string';
+      need(known, `demo.default_scenario "${ds}" matches no verb or scenario`);
+    }
+    if (app.demo.estimated_startup_seconds != null) {
+      need(typeof app.demo.estimated_startup_seconds === 'number', 'demo.estimated_startup_seconds must be a number');
+    }
+    // hosted apps that want a derived orchestrator config declare how to run
+    if (app.demo.orchestrator) {
+      const o = app.demo.orchestrator;
+      need(typeof o.image === 'string', 'demo.orchestrator.image is required when the section is present');
+      need(Array.isArray(o.command) || typeof o.command === 'string', 'demo.orchestrator.command must be a string or array');
+      need(typeof o.gateway_port === 'number', 'demo.orchestrator.gateway_port must be a number');
+    } else if (app.demo.hosted === true) {
+      warn.push('demo.hosted is true but no demo.orchestrator section: the orchestrator config cannot be derived');
+    }
+  }
+
+  return { id: app.id ?? path.basename(app.dir ?? '?'), ok: errors.length === 0, errors, warnings: warn };
+}
+
+export function validateApps(apps) {
+  const results = apps.map((a) =>
+    a.parse_error
+      ? { id: a.id, ok: false, errors: [`robium-app.yaml failed to parse: ${a.parse_error}`], warnings: [] }
+      : validateApp(a));
+  return { ok: results.every((r) => r.ok), results };
+}
+
+export function appValidate({ appsDir, flags = {}, log = console.log } = {}) {
+  const { ok, results } = validateApps(loadApps(appsDir));
+  if (flags.json) {
+    log(JSON.stringify({ ok, apps_dir: appsDir, results }, null, 2));
+    return ok ? 0 : 1;
+  }
+  log(`validating robium-app.yaml files in ${appsDir}\n`);
+  for (const r of results) {
+    log(`  ${r.ok ? '✓' : '✗'} ${r.id}`);
+    for (const e of r.errors) log(`      error: ${e}`);
+    for (const w of r.warnings) log(`      warn:  ${w}`);
+  }
+  log(ok ? '\nAll apps valid.' : '\nValidation failed: fix the errors above.');
+  return ok ? 0 : 1;
+}

--- a/cli/src/apps.js
+++ b/cli/src/apps.js
@@ -1,0 +1,239 @@
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+import { runChecks } from './doctor.js';
+
+// ---------------------------------------------------------------------------
+// robium-app.yaml parser. Deliberately a YAML *subset* so the CLI stays
+// zero-dependency: 2-space-indented nested maps, scalar values, inline
+// arrays [a, b], empty maps {}, quoted strings, null/true/false/numbers,
+// and comments (full-line or trailing after whitespace). The reference-apps
+// spec (section 5) keeps files inside this subset; the future validator
+// (v1.1) enforces it.
+// ---------------------------------------------------------------------------
+
+function parseScalar(raw) {
+  let s = raw.trim();
+  // trailing comment: " #" outside quotes
+  if (!s.startsWith('"') && !s.startsWith("'")) {
+    const m = s.match(/\s+#.*$/);
+    if (m) s = s.slice(0, m.index).trim();
+  }
+  if (s === '' || s === 'null' || s === '~') return null;
+  if (s === '{}') return {};
+  if (s === '[]') return [];
+  if (s === 'true') return true;
+  if (s === 'false') return false;
+  if (s.startsWith('[') && s.endsWith(']')) {
+    const inner = s.slice(1, -1).trim();
+    return inner === '' ? [] : inner.split(',').map((x) => parseScalar(x));
+  }
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  if (/^-?\d+(\.\d+)?$/.test(s)) return Number(s);
+  return s;
+}
+
+export function parseAppYaml(text) {
+  const root = {};
+  // stack of [indent, object] — the object currently collecting keys
+  const stack = [[-1, root]];
+  const lines = text.split('\n');
+  for (let n = 0; n < lines.length; n++) {
+    const line = lines[n];
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const indent = line.length - line.trimStart().length;
+    const m = line.trim().match(/^([A-Za-z0-9_-]+):(.*)$/);
+    if (!m) throw new Error(`robium-app.yaml line ${n + 1}: expected "key: value", got "${line.trim()}"`);
+    const [, key, rest] = m;
+    while (stack.length > 1 && indent <= stack[stack.length - 1][0]) stack.pop();
+    const parent = stack[stack.length - 1][1];
+    if (rest.trim() === '' || /^\s+#/.test(rest)) {
+      const child = {};
+      parent[key] = child;
+      stack.push([indent, child]);
+    } else {
+      const v = parseScalar(rest);
+      parent[key] = v;
+      if (v && typeof v === 'object' && !Array.isArray(v)) stack.push([indent, v]);
+    }
+  }
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Apps-directory resolution. Documented rule, no hardcoded layouts:
+//   1. --dir flag
+//   2. ROBIUM_APPS_DIR environment variable
+//   3. walk up from cwd: the first directory that contains REGISTRY.md and
+//      at least one <app>/robium-app.yaml (covers running from inside an
+//      apps repo or any app subdirectory)
+// ---------------------------------------------------------------------------
+
+function looksLikeAppsRepo(dir) {
+  if (!existsSync(path.join(dir, 'REGISTRY.md'))) return false;
+  try {
+    return readdirSync(dir).some((e) => existsSync(path.join(dir, e, 'robium-app.yaml')));
+  } catch {
+    return false;
+  }
+}
+
+export function findAppsDir({ dir, env = process.env, cwd = process.cwd() } = {}) {
+  if (dir) return existsSync(dir) ? path.resolve(dir) : null;
+  if (env.ROBIUM_APPS_DIR) return existsSync(env.ROBIUM_APPS_DIR) ? path.resolve(env.ROBIUM_APPS_DIR) : null;
+  let d = path.resolve(cwd);
+  const home = os.homedir();
+  while (true) {
+    if (looksLikeAppsRepo(d)) return d;
+    const up = path.dirname(d);
+    if (up === d || d === home) return null;
+    d = up;
+  }
+}
+
+export function loadApps(appsDir) {
+  const apps = [];
+  for (const entry of readdirSync(appsDir)) {
+    const yamlPath = path.join(appsDir, entry, 'robium-app.yaml');
+    if (!existsSync(yamlPath) || !statSync(path.join(appsDir, entry)).isDirectory()) continue;
+    try {
+      const meta = parseAppYaml(readFileSync(yamlPath, 'utf8'));
+      apps.push({ dir: path.join(appsDir, entry), ...meta });
+    } catch (e) {
+      apps.push({ dir: path.join(appsDir, entry), id: entry, parse_error: e.message });
+    }
+  }
+  return apps.sort((a, b) => String(a.id).localeCompare(String(b.id)));
+}
+
+// Resolve what `app run`/`app check` should execute. Commands are argv-split
+// on whitespace (the contract is plain commands like "make demo" — no shell).
+export function resolveCommand(app, { verb, scenario } = {}) {
+  if (scenario) {
+    const s = app.scenarios?.[scenario];
+    if (!s?.command) {
+      const known = Object.keys(app.scenarios ?? {});
+      return { error: `unknown scenario "${scenario}" for ${app.id}${known.length ? ` (known: ${known.join(', ')})` : ' (none declared)'}` };
+    }
+    return { command: s.command };
+  }
+  const cmd = app.verbs?.[verb] ?? (verb === 'demo' ? app.runtime?.entrypoint : undefined);
+  if (!cmd) return { error: `${app.id} declares no "${verb}" verb in robium-app.yaml` };
+  return { command: cmd };
+}
+
+function execInApp(command, dir, { spawnFn = spawn } = {}) {
+  return new Promise((resolve) => {
+    const [bin, ...args] = command.split(/\s+/);
+    const child = spawnFn(bin, args, { cwd: dir, stdio: 'inherit' });
+    child.on('error', (e) => {
+      console.error(`failed to start "${command}": ${e.message}`);
+      resolve(1);
+    });
+    child.on('exit', (code) => resolve(code ?? 1));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Subcommands
+// ---------------------------------------------------------------------------
+
+const APP_USAGE = `robium app: work with reference applications (robium-app.yaml contract)
+
+Usage:
+  npx robium-ai app list [--json]                  List apps in the apps repo
+  npx robium-ai app describe <id> [--json]         Show one app's metadata
+  npx robium-ai app check <id>                     Preflight: doctor facts + the app's own make check
+  npx robium-ai app run <id> [--scenario NAME]     Run the app's demo (or a declared scenario)
+
+Apps repo resolution: --dir <path>, else $ROBIUM_APPS_DIR, else walk up from
+the current directory to the first repo with REGISTRY.md + robium-app.yaml files.`;
+
+function requireAppsDir(flags, log) {
+  const appsDir = findAppsDir({ dir: flags.dir });
+  if (!appsDir) {
+    log('No apps repo found. Pass --dir <path>, set ROBIUM_APPS_DIR, or run from inside an apps checkout.');
+    return null;
+  }
+  return appsDir;
+}
+
+function requireApp(apps, id, log) {
+  const app = apps.find((a) => a.id === id);
+  if (!app) {
+    log(`Unknown app "${id ?? ''}". Known: ${apps.map((a) => a.id).join(', ') || '(none)'}`);
+    return null;
+  }
+  if (app.parse_error) {
+    log(`robium-app.yaml for ${id} failed to parse: ${app.parse_error}`);
+    return null;
+  }
+  return app;
+}
+
+export async function appCmd({ args = [], flags = {}, log = console.log, exec = execInApp, checks = runChecks } = {}) {
+  const sub = args[0];
+  const id = args[1];
+  if (!sub || flags.help) {
+    log(APP_USAGE);
+    return sub ? 0 : 1;
+  }
+  const appsDir = requireAppsDir(flags, log);
+  if (!appsDir) return 1;
+  const apps = loadApps(appsDir);
+
+  switch (sub) {
+    case 'list': {
+      if (flags.json) {
+        log(JSON.stringify({ apps_dir: appsDir, apps }, null, 2));
+        return 0;
+      }
+      log(`apps in ${appsDir}\n`);
+      const w = Math.max(...apps.map((a) => String(a.id).length), 2);
+      for (const a of apps) {
+        if (a.parse_error) { log(`  ${String(a.id).padEnd(w)}  PARSE ERROR: ${a.parse_error}`); continue; }
+        log(`  ${String(a.id).padEnd(w)}  ${String(a.status).padEnd(12)} ${a.runtime?.kind ?? '?'}  ${a.summary ?? ''}`);
+      }
+      return apps.some((a) => a.parse_error) ? 1 : 0;
+    }
+    case 'describe': {
+      const app = requireApp(apps, id, log);
+      if (!app) return 1;
+      log(JSON.stringify(app, null, 2));
+      return 0;
+    }
+    case 'check': {
+      const app = requireApp(apps, id, log);
+      if (!app) return 1;
+      // Environment facts relevant to the app's declared runtime/requirements.
+      const results = await checks();
+      const relevant = results.filter((r) =>
+        (app.runtime?.kind === 'docker' && ['docker', 'disk', 'platform'].includes(r.id)) ||
+        (app.runtime?.kind === 'uv' && ['python', 'disk', 'platform', 'gpu'].includes(r.id)) ||
+        (app.runtime?.kind === 'remote-gpu' && ['python', 'platform'].includes(r.id)) ||
+        (app.runtime?.kind === 'hardware' && ['platform'].includes(r.id)));
+      for (const r of relevant) log(`  doctor: ${r.label} — ${r.detail}`);
+      if (app.requirements?.gpu === 'remote') log('  note: GPU work runs remotely for this app; nothing local to verify');
+      const resolved = resolveCommand(app, { verb: 'check' });
+      if (resolved.error) {
+        log(`  ${resolved.error} — doctor facts above are the whole preflight`);
+        return 0;
+      }
+      return exec(resolved.command, app.dir);
+    }
+    case 'run': {
+      const app = requireApp(apps, id, log);
+      if (!app) return 1;
+      const resolved = resolveCommand(app, { verb: 'demo', scenario: flags.scenario });
+      if (resolved.error) { log(resolved.error); return 1; }
+      log(`→ ${resolved.command}  (in ${app.dir})`);
+      return exec(resolved.command, app.dir);
+    }
+    default:
+      log(`Unknown app subcommand: ${sub}\n\n${APP_USAGE}`);
+      return 1;
+  }
+}

--- a/cli/src/apps.js
+++ b/cli/src/apps.js
@@ -3,6 +3,8 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import os from 'node:os';
 import { runChecks } from './doctor.js';
+import { appValidate } from './appValidate.js';
+import { scaffoldApp } from './appNew.js';
 
 // ---------------------------------------------------------------------------
 // robium-app.yaml parser. Deliberately a YAML *subset* so the CLI stays
@@ -148,6 +150,8 @@ Usage:
   npx robium-ai app describe <id> [--json]         Show one app's metadata
   npx robium-ai app check <id>                     Preflight: doctor facts + the app's own make check
   npx robium-ai app run <id> [--scenario NAME]     Run the app's demo (or a declared scenario)
+  npx robium-ai app validate [--json]              Validate every robium-app.yaml (CI-friendly)
+  npx robium-ai app new <id> --from <existing-id>  Scaffold by copying the closest shipped app
 
 Apps repo resolution: --dir <path>, else $ROBIUM_APPS_DIR, else walk up from
 the current directory to the first repo with REGISTRY.md + robium-app.yaml files.`;
@@ -183,6 +187,8 @@ export async function appCmd({ args = [], flags = {}, log = console.log, exec = 
   }
   const appsDir = requireAppsDir(flags, log);
   if (!appsDir) return 1;
+  if (sub === 'validate') return appValidate({ appsDir, flags, log });
+  if (sub === 'new') return scaffoldApp({ appsDir, id, from: flags.from, log });
   const apps = loadApps(appsDir);
 
   switch (sub) {

--- a/cli/test/appValidate.test.js
+++ b/cli/test/appValidate.test.js
@@ -1,0 +1,140 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parseAppYaml } from '../src/apps.js';
+import { validateApp, validateApps } from '../src/appValidate.js';
+import { scaffoldApp } from '../src/appNew.js';
+import { appCmd } from '../src/apps.js';
+
+const GOOD = `schema_version: "1"
+id: good-app
+name: Good app
+summary: Does a thing.
+version: 1.0.0
+status: stable
+license: MIT
+runtime:
+  kind: docker
+  entrypoint: make demo
+verbs:
+  demo: make demo
+  smoke: make smoke
+  check: make check
+scenarios:
+  alt:
+    command: make alt
+    summary: alternative flow
+requirements:
+  hardware: []
+  gpu: none
+  network: optional
+demo:
+  default_scenario: demo
+  hosted: false
+  estimated_startup_seconds: 30
+`;
+
+function app(yaml, dirname = 'good-app') {
+  return { dir: `/x/${dirname}`, ...parseAppYaml(yaml) };
+}
+
+test('validateApp: fully valid app has no errors', () => {
+  const r = validateApp(app(GOOD));
+  assert.deepEqual(r.errors, []);
+  assert.ok(r.ok);
+});
+
+test('validateApp: precise per-field errors', () => {
+  const r = validateApp(app(GOOD
+    .replace('status: stable', 'status: shiny')
+    .replace('version: 1.0.0', 'version: v1')
+    .replace('kind: docker', 'kind: bare-metal')
+    .replace('  smoke: make smoke\n', ''), 'good-app'));
+  assert.ok(!r.ok);
+  assert.ok(r.errors.some((e) => e.includes('status must be one of')));
+  assert.ok(r.errors.some((e) => e.includes('version must be MAJOR.MINOR.PATCH')));
+  assert.ok(r.errors.some((e) => e.includes('runtime.kind must be one of')));
+  assert.ok(r.errors.some((e) => e.includes('verbs.smoke is required')));
+});
+
+test('validateApp: id must match directory name', () => {
+  const r = validateApp(app(GOOD, 'other-dir'));
+  assert.ok(r.errors.some((e) => e.includes('must equal the directory name')));
+});
+
+test('validateApp: default_scenario must resolve; hosted without orchestrator warns', () => {
+  const r = validateApp(app(GOOD.replace('default_scenario: demo', 'default_scenario: ghost')));
+  assert.ok(r.errors.some((e) => e.includes('matches no verb or scenario')));
+
+  const hosted = validateApp(app(GOOD.replace('hosted: false', 'hosted: true')));
+  assert.ok(hosted.ok);
+  assert.ok(hosted.warnings.some((w) => w.includes('cannot be derived')));
+});
+
+test('validateApp: orchestrator section field checks', () => {
+  const y = GOOD.replace('hosted: false', `hosted: true
+  orchestrator:
+    image: good-app:latest
+    command: [/entrypoint.sh, make, demo]
+    gateway_port: 8765`);
+  const r = validateApp(app(y));
+  assert.ok(r.ok, JSON.stringify(r.errors));
+
+  const bad = validateApp(app(y.replace('    gateway_port: 8765', '    gateway_port: eight')));
+  assert.ok(bad.errors.some((e) => e.includes('gateway_port must be a number')));
+});
+
+test('validateApps + app validate subcommand over a repo', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'robium-val-'));
+  writeFileSync(path.join(root, 'REGISTRY.md'), '# r\n');
+  mkdirSync(path.join(root, 'good-app'));
+  writeFileSync(path.join(root, 'good-app', 'robium-app.yaml'), GOOD);
+  mkdirSync(path.join(root, 'bad-app'));
+  writeFileSync(path.join(root, 'bad-app', 'robium-app.yaml'), 'id: bad-app\n');
+
+  const lines = [];
+  const code = await appCmd({ args: ['validate'], flags: { dir: root }, log: (...a) => lines.push(a.join(' ')) });
+  assert.equal(code, 1);
+  assert.ok(lines.some((l) => l.includes('✓ good-app')));
+  assert.ok(lines.some((l) => l.includes('✗ bad-app')));
+
+  const j = [];
+  await appCmd({ args: ['validate'], flags: { dir: root, json: true }, log: (...a) => j.push(a.join(' ')) });
+  const out = JSON.parse(j.join('\n'));
+  assert.equal(out.ok, false);
+  assert.equal(out.results.length, 2);
+});
+
+test('app new: scaffolds by copy, resets metadata, excludes artifacts', async () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'robium-new-'));
+  writeFileSync(path.join(root, 'REGISTRY.md'), '# r\n');
+  mkdirSync(path.join(root, 'good-app', 'src'), { recursive: true });
+  mkdirSync(path.join(root, 'good-app', '.venv'));
+  mkdirSync(path.join(root, 'good-app', 'outputs'));
+  writeFileSync(path.join(root, 'good-app', 'robium-app.yaml'), GOOD);
+  writeFileSync(path.join(root, 'good-app', 'Makefile'), 'demo:\n\techo hi\n');
+  writeFileSync(path.join(root, 'good-app', 'src', 'main.py'), 'print(1)\n');
+  writeFileSync(path.join(root, 'good-app', '.venv', 'junk'), 'x');
+  writeFileSync(path.join(root, 'good-app', 'outputs', 'big.bin'), 'x');
+
+  const lines = [];
+  const code = scaffoldApp({ appsDir: root, id: 'new-thing', from: 'good-app', log: (...a) => lines.push(a.join(' ')) });
+  assert.equal(code, 0);
+  assert.ok(existsSync(path.join(root, 'new-thing', 'Makefile')));
+  assert.ok(existsSync(path.join(root, 'new-thing', 'src', 'main.py')));
+  assert.ok(!existsSync(path.join(root, 'new-thing', '.venv')));
+  assert.ok(!existsSync(path.join(root, 'new-thing', 'outputs')));
+  const yaml = parseAppYaml(readFileSync(path.join(root, 'new-thing', 'robium-app.yaml'), 'utf8'));
+  assert.equal(yaml.id, 'new-thing');
+  assert.equal(yaml.version, '0.1.0');
+  assert.equal(yaml.status, 'experimental');
+  assert.ok(lines.some((l) => l.includes('REGISTRY.md')));
+
+  // guards
+  assert.equal(scaffoldApp({ appsDir: root, id: 'new-thing', from: 'good-app', log: () => {} }), 1); // exists
+  assert.equal(scaffoldApp({ appsDir: root, id: 'Bad_Name', from: 'good-app', log: () => {} }), 1);
+  assert.equal(scaffoldApp({ appsDir: root, id: 'x2', from: 'ghost', log: () => {} }), 1);
+  assert.equal(scaffoldApp({ appsDir: root, id: 'x3', log: () => {} }), 1); // no --from
+});

--- a/cli/test/apps.test.js
+++ b/cli/test/apps.test.js
@@ -1,0 +1,182 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { parseAppYaml, findAppsDir, loadApps, resolveCommand, appCmd } from '../src/apps.js';
+
+const SAMPLE = `schema_version: "1"
+id: indoor-navigation
+name: Indoor navigation (TurtleBot 3 + Nav2)
+summary: SLAM builds a map, Nav2 drives clicked goals.
+version: 1.0.0
+status: stable
+license: MIT
+tags: [navigation, ros2, nav2]
+
+runtime:
+  kind: docker
+  entrypoint: make demo
+
+verbs:
+  build: make build
+  demo: make demo
+  smoke: make smoke
+  check: make check
+  down: make down
+
+scenarios:
+  slam:
+    command: make slam
+    summary: drive the mapping route and save the map
+  nav:
+    command: make nav
+    summary: navigation on the saved map
+
+requirements:
+  hardware: []
+  gpu: none              # trailing comment
+  network: optional
+
+demo:
+  default_scenario: demo
+  hosted: true
+  estimated_startup_seconds: 45
+
+artifacts:
+  thumbnail: null
+  case_study: null
+`;
+
+test('parseAppYaml: full reference-shape file', () => {
+  const a = parseAppYaml(SAMPLE);
+  assert.equal(a.schema_version, '1');           // quoted stays string
+  assert.equal(a.id, 'indoor-navigation');
+  assert.equal(a.name, 'Indoor navigation (TurtleBot 3 + Nav2)');
+  assert.deepEqual(a.tags, ['navigation', 'ros2', 'nav2']);
+  assert.equal(a.runtime.kind, 'docker');
+  assert.equal(a.verbs.check, 'make check');
+  assert.equal(a.scenarios.slam.command, 'make slam');
+  assert.equal(a.scenarios.nav.summary, 'navigation on the saved map');
+  assert.deepEqual(a.requirements.hardware, []);
+  assert.equal(a.requirements.gpu, 'none');       // trailing comment stripped
+  assert.equal(a.demo.hosted, true);
+  assert.equal(a.demo.estimated_startup_seconds, 45);
+  assert.equal(a.artifacts.thumbnail, null);
+});
+
+test('parseAppYaml: empty inline map and version-like strings', () => {
+  const a = parseAppYaml('id: x\nscenarios: {}\nversion: 0.1.0\n');
+  assert.deepEqual(a.scenarios, {});
+  assert.equal(a.version, '0.1.0');               // not a number
+});
+
+test('parseAppYaml: rejects non key-value lines', () => {
+  assert.throws(() => parseAppYaml('- just a list item\n'), /expected "key: value"/);
+});
+
+function makeAppsRepo() {
+  const root = mkdtempSync(path.join(tmpdir(), 'robium-apps-'));
+  writeFileSync(path.join(root, 'REGISTRY.md'), '# registry\n');
+  mkdirSync(path.join(root, 'nav-app'));
+  writeFileSync(path.join(root, 'nav-app', 'robium-app.yaml'), SAMPLE);
+  mkdirSync(path.join(root, 'broken-app'));
+  writeFileSync(path.join(root, 'broken-app', 'robium-app.yaml'), '- not: [valid\n');
+  mkdirSync(path.join(root, 'not-an-app'));       // no yaml → ignored
+  return root;
+}
+
+test('findAppsDir: explicit dir, env, and cwd walk-up', () => {
+  const root = makeAppsRepo();
+  assert.equal(findAppsDir({ dir: root }), root);
+  assert.equal(findAppsDir({ env: { ROBIUM_APPS_DIR: root }, cwd: '/' }), root);
+  const deep = path.join(root, 'nav-app');
+  assert.equal(findAppsDir({ env: {}, cwd: deep }), root);
+  assert.equal(findAppsDir({ dir: path.join(root, 'nope') }), null);
+});
+
+test('loadApps: parses good apps, flags broken ones, skips non-apps', () => {
+  const apps = loadApps(makeAppsRepo());
+  assert.equal(apps.length, 2);
+  const broken = apps.find((a) => a.id === 'broken-app');
+  assert.match(broken.parse_error, /expected "key: value"/);
+  const nav = apps.find((a) => a.id === 'indoor-navigation');
+  assert.equal(nav.runtime.kind, 'docker');
+});
+
+test('resolveCommand: verb, scenario, and error paths', () => {
+  const app = parseAppYaml(SAMPLE);
+  assert.deepEqual(resolveCommand(app, { verb: 'demo' }), { command: 'make demo' });
+  assert.deepEqual(resolveCommand(app, { verb: 'check' }), { command: 'make check' });
+  assert.deepEqual(resolveCommand(app, { scenario: 'slam' }), { command: 'make slam' });
+  assert.match(resolveCommand(app, { scenario: 'zzz' }).error, /known: slam, nav/);
+  const bare = parseAppYaml('id: y\nruntime:\n  entrypoint: make go\n');
+  assert.deepEqual(resolveCommand(bare, { verb: 'demo' }), { command: 'make go' });
+  assert.match(resolveCommand(bare, { verb: 'check' }).error, /no "check" verb/);
+});
+
+function capture() {
+  const lines = [];
+  return { log: (...a) => lines.push(a.join(' ')), lines };
+}
+
+test('app list: table and --json', async () => {
+  const root = makeAppsRepo();
+  const { log, lines } = capture();
+  const code = await appCmd({ args: ['list'], flags: { dir: root }, log });
+  assert.equal(code, 1); // broken-app is a parse error
+  assert.ok(lines.some((l) => l.includes('indoor-navigation') && l.includes('docker')));
+  assert.ok(lines.some((l) => l.includes('PARSE ERROR')));
+
+  const j = capture();
+  await appCmd({ args: ['list'], flags: { dir: root, json: true }, log: j.log });
+  const parsed = JSON.parse(j.lines.join('\n'));
+  assert.equal(parsed.apps.length, 2);
+});
+
+test('app run: execs resolved command in app dir; scenario flag; unknown id', async () => {
+  const root = makeAppsRepo();
+  const calls = [];
+  const exec = async (command, dir) => { calls.push({ command, dir }); return 0; };
+  const { log } = capture();
+
+  assert.equal(await appCmd({ args: ['run', 'indoor-navigation'], flags: { dir: root }, log, exec }), 0);
+  assert.equal(await appCmd({ args: ['run', 'indoor-navigation'], flags: { dir: root, scenario: 'slam' }, log, exec }), 0);
+  assert.deepEqual(calls.map((c) => c.command), ['make demo', 'make slam']);
+  assert.ok(calls[0].dir.endsWith('nav-app'));
+
+  const bad = capture();
+  assert.equal(await appCmd({ args: ['run', 'ghost'], flags: { dir: root }, log: bad.log, exec }), 1);
+  assert.ok(bad.lines.some((l) => l.includes('Unknown app "ghost"')));
+});
+
+test('app check: doctor facts + app check verb; graceful when verb missing', async () => {
+  const root = makeAppsRepo();
+  const calls = [];
+  const exec = async (command, dir) => { calls.push({ command, dir }); return 0; };
+  const checks = async () => [
+    { id: 'docker', label: 'Docker', status: 'pass', detail: '27.0.0' },
+    { id: 'python', label: 'Python / uv', status: 'pass', detail: '3.12' },
+  ];
+  const { log, lines } = capture();
+  assert.equal(await appCmd({ args: ['check', 'indoor-navigation'], flags: { dir: root }, log, exec, checks }), 0);
+  assert.ok(lines.some((l) => l.includes('doctor: Docker')));       // docker runtime → docker fact shown
+  assert.ok(!lines.some((l) => l.includes('doctor: Python')));      // not relevant to docker kind
+  assert.deepEqual(calls.map((c) => c.command), ['make check']);
+
+  // App without a check verb: doctor facts are the whole preflight, exit 0.
+  mkdirSync(path.join(root, 'thin-app'));
+  writeFileSync(path.join(root, 'thin-app', 'robium-app.yaml'),
+    'id: thin-app\nstatus: experimental\nruntime:\n  kind: uv\n  entrypoint: make demo\n');
+  const thin = capture();
+  assert.equal(await appCmd({ args: ['check', 'thin-app'], flags: { dir: root }, log: thin.log, exec, checks }), 0);
+  assert.ok(thin.lines.some((l) => l.includes('doctor facts above are the whole preflight')));
+});
+
+test('app describe: dumps metadata json', async () => {
+  const root = makeAppsRepo();
+  const { log, lines } = capture();
+  assert.equal(await appCmd({ args: ['describe', 'indoor-navigation'], flags: { dir: root }, log }), 0);
+  const obj = JSON.parse(lines.join('\n'));
+  assert.equal(obj.verbs.smoke, 'make smoke');
+});

--- a/docs/superpowers/specs/2026-08-05-reference-applications-design.md
+++ b/docs/superpowers/specs/2026-08-05-reference-applications-design.md
@@ -283,15 +283,23 @@ Scaffolding is `robium-ai app new <id> --from <closest-app>`: copy a shipped,
 battle-tested app and diverge (the REGISTRY.md "Bootstrap for" rule), rather
 than generating from abstract templates.
 
-Roadmap:
+Roadmap (status as of 2026-08-05):
 
-- **v1:** `robium-app.yaml` schema agreed; yaml files added to the five
-  shipped apps; `robium-ai app list|describe|run|check` implemented against
-  them; `make check` added per app.
-- **v1.1:** schema validation in CI; `app new`; website ingestion from yaml;
-  orchestrator config derived from yaml.
-- **v1.2:** hosted-demo conventions extracted into a reusable gateway package;
-  compatibility badges; reusable UI components.
+- **v1 — shipped:** `robium-app.yaml` schema agreed; yaml files on all five
+  shipped apps plus the archived workspace flavor; `robium-ai app
+  list|describe|run|check`; `make check` per app, honestly scoped for
+  hardware/remote-GPU apps. (robium#67, robium-internal-apps#2)
+- **v1.1 — shipped:** `app validate` (per-field errors, --json) run by apps
+  CI on every push/PR; `app new <id> --from <app>` scaffold-by-copy;
+  website catalog ingestion from yaml (fetch-apps.mjs, /apps page);
+  orchestrator configs derived from the yamls' demo.orchestrator sections
+  (sync-demos.mjs, drift check in site smoke). (robium#67,
+  robium-internal-apps#2, robium-website#11)
+- **v1.2 — shipped:** hosted-demo contract extracted to the vendorable
+  shared/demo-gateway package (env-configured, stdlib contract test in CI);
+  compatibility badges machine-derived from the metadata; the LiveDemo
+  island reusable by any gateway-contract demo. (robium-internal-apps#2,
+  robium-website#11)
 - **Later:** scenario registry, benchmark datasets, community galleries,
   cross-app composition, only after the core is reliable.
 

--- a/docs/superpowers/specs/2026-08-05-reference-applications-design.md
+++ b/docs/superpowers/specs/2026-08-05-reference-applications-design.md
@@ -122,7 +122,13 @@ robium-ai app new <id> [--from <app>]    # scaffold by copying the closest exist
 
 `app run` and `app check` do not reimplement anything: they read
 `robium-app.yaml` and exec the mapped command in the app directory, streaming
-output. `app check` layers `robium-ai doctor` facts (Docker, GPU, disk,
+output. The apps repo is resolved by rule, never hardcoded: `--dir <path>`,
+else `$ROBIUM_APPS_DIR`, else walk up from the current directory to the first
+repo containing REGISTRY.md plus robium-app.yaml files.
+
+Files stay within a small YAML subset so the zero-dependency CLI can parse
+them: 2-space-indented nested maps, scalars, inline arrays, `{}`, quoted
+strings, and comments. No anchors, no multi-line strings, no inline maps. `app check` layers `robium-ai doctor` facts (Docker, GPU, disk,
 Python/uv) against the app's declared `requirements`. `app new` follows the
 registry's bootstrap rule: copy the closest shipped app and diverge, instead
 of abstract templates. Every command supports non-interactive use and `--json`
@@ -175,8 +181,12 @@ verbs:                     # standard verbs -> actual commands (section 4b)
   down: make down
 
 scenarios:                 # optional; name -> command + one-line description
-  slam: {command: make slam, summary: drive the mapping route and save the map}
-  nav: {command: make nav, summary: navigation on the saved map, manual init pose}
+  slam:
+    command: make slam
+    summary: drive the mapping route and save the map
+  nav:
+    command: make nav
+    summary: navigation on the saved map, manual init pose
 
 requirements:
   hardware: []             # e.g. [turtlebot4] for real-robot apps


### PR DESCRIPTION
Implements the CLI + spec share of the reference-apps roadmap, ALL versions
(docs/superpowers/specs/2026-08-05-reference-applications-design.md).

**v1**
- `robium-ai app list | describe <id> [--json] | check <id> | run <id> [--scenario NAME]`
- Zero-dependency YAML-subset parser for robium-app.yaml (subset documented in the spec)
- Apps repo resolved by rule (--dir, $ROBIUM_APPS_DIR, cwd walk-up), never hardcoded
- `app check` layers doctor facts relevant to runtime.kind, then execs the app's own `make check`

**v1.1**
- `app validate [--json]`: schema "1" validation with per-field errors — the single
  source of truth the apps-repo CI workflow runs (robium-internal-apps#2)
- `app new <id> --from <existing-app>`: scaffold by copying the closest shipped app
  (registry bootstrap rule), artifacts excluded, metadata reset

**Spec**
- Fixed where reality sharpened it: nested scenarios example, resolution rule,
  YAML subset documented; roadmap section now carries shipped-status + PR refs.

Tests 64/64 green; exercised live against the converted apps (validate: 6/6 valid).

Companion PRs: robium-internal-apps#2 (yamls, make check, CI, shared/demo-gateway),
robium-website#11 (catalog ingestion, derived orchestrator configs, LiveDemo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)